### PR TITLE
Match query params after .jxl file extension

### DIFF
--- a/jxl.js
+++ b/jxl.js
@@ -68,11 +68,12 @@
   }
 
   new MutationObserver(mutations => mutations.forEach(mutation => mutation.addedNodes.forEach(el => {
-    if (el instanceof HTMLImageElement && el.src.endsWith('.jxl'))
+    const isJxl = (str) => (str.match(/\.jxl(\?.*)?$/));
+    if (el instanceof HTMLImageElement && isJxl(el.src))
       el.onerror = () => decode(el, false, false);
-    else if (el instanceof HTMLSourceElement && el.srcset.endsWith('.jxl'))
+    else if (el instanceof HTMLSourceElement && isJxl(el.srcset))
       decode(el, false, true);
-    else if (el instanceof Element && getComputedStyle(el).backgroundImage.endsWith('.jxl")'))
+    else if (el instanceof Element && isJxl(getComputedStyle(el).backgroundImage.replace(new RegExp('"\\)$'), '')))
       decode(el, true, false);
   }))).observe(document.documentElement, {subtree: true, childList: true});
 }());


### PR DESCRIPTION
Sometimes image url also contains query parameters like auth and time. 

After this change, it should match urls containing query parameters. Example:  
```
<img alt="" src="https://example.org/example.jxl?auth=abcdef012345&refresh=1682510679">
```